### PR TITLE
Pass sqid into decode() as `std::string_view`

### DIFF
--- a/include/sqids/sqids.hpp
+++ b/include/sqids/sqids.hpp
@@ -109,7 +109,7 @@ public:
     bool containsMultibyteCharacters(const std::string& input) const;
 
     std::string encode(const std::vector<T>& numbers) const;
-    std::vector<T> decode(const std::string& id) const;
+    std::vector<T> decode(std::string_view id) const;
 
     static constexpr T maxValue = std::numeric_limits<T>::max();
 
@@ -294,7 +294,7 @@ std::string Sqids<T>::encode(const std::vector<T>& numbers) const
 /// @return    The sequence of integers
 ///
 template<typename T>
-typename std::vector<T> Sqids<T>::decode(const std::string& id) const
+typename std::vector<T> Sqids<T>::decode(std::string_view id) const
 {
     // If an empty string is given, return an empty sequence
     if (id.empty()) {


### PR DESCRIPTION
`Sqids<T>::decode()` currently expects a `const std::string &`. My use case requires to decode multiple sqids which are stored in a composite structure. It is trivial and cheap to provide individual sqids as `std::string_view` (aka. a ptr + sz), but providing a `std::string` (respective a const reference to a `std::string`) requires construction of a `std::string` which means a heap allocation + copy.

This PR changes the API to `std::string_view`. Existing use cases continue to work as `std::string` implicitly converts to `std::string_view`.